### PR TITLE
Use autopilot whitelist bit for AP top plays

### DIFF
--- a/main.py
+++ b/main.py
@@ -345,7 +345,7 @@ async def update_top_plays() -> None:
     for table, whitelist_int in (
         ("scores", 1),
         ("scores_relax", 2),
-        ("scores_ap", 2),
+        ("scores_ap", 4),
     ):
         query = f"""
             SELECT users.username,


### PR DESCRIPTION
Summary:
- use the Autopilot whitelist bit for scores_ap top-play cache filtering

Verification:
- python3 -m py_compile main.py
- git diff --check